### PR TITLE
use correct framework

### DIFF
--- a/ReverseProxy.Store.Distributed/ReverseProxy.Store.Distributed.csproj
+++ b/ReverseProxy.Store.Distributed/ReverseProxy.Store.Distributed.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net80</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
 	  <Version>2.1.0</Version>

--- a/ReverseProxy.Store.EFCore/ReverseProxy.Store.EFCore.csproj
+++ b/ReverseProxy.Store.EFCore/ReverseProxy.Store.EFCore.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net80</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
 	  <Version>2.1.0</Version>
 	  <Authors>FunShow</Authors>
 	  <Description>https://github.com/fanslead/ReverseProxy.Store</Description>

--- a/ReverseProxy.Store/ReverseProxy.Store.csproj
+++ b/ReverseProxy.Store/ReverseProxy.Store.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net80</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <Version>2.1.0</Version>
     <Authors>FunShow</Authors>
     <Description>https://github.com/fanslead/ReverseProxy.Store</Description>

--- a/ReverseProxy.WebApi/ReverseProxy.WebApi.csproj
+++ b/ReverseProxy.WebApi/ReverseProxy.WebApi.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>net80</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
   </PropertyGroup>


### PR DESCRIPTION
the undocumented names (without period in dotnet 5+) can drop their support when move to double-digit (to avoid potential conflicts) https://learn.microsoft.com/en-us/dotnet/standard/frameworks#supported-target-frameworks